### PR TITLE
Escape file contents in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ jobs:
         run: |
           echo "Function Code Is"
           cp lib/function.js lib/function.txt
-          value=`cat lib/function.txt`
+          value="$(< lib/function.txt)"
+          value="${value//'%'/'%25'}"
+          value="${value//$'\n'/'%0A'}"
+          value="${value//$'\r'/'%0D'}"
           echo $value
           echo "::set-output name=function_code::$value"
         id: checkout


### PR DESCRIPTION
This change updates the example workflow YAML file to escape the contents of the function. This replaces `'%'`, `'\r'`, and `'\n'` characters with their URI-encoded values. This is decoded automatically by later action stages.